### PR TITLE
Use a lowercase 'immutable' module name

### DIFF
--- a/shallowEqualImmutable.js
+++ b/shallowEqualImmutable.js
@@ -1,4 +1,4 @@
-var Immutable = require('Immutable');
+var Immutable = require('immutable');
 
 function shallowEqualImmutable(objA, objB) {
   if (Immutable.is(objA, objB)) {


### PR DESCRIPTION
Webpack complains about `require('Immutable')`:

```
WARNING in ./~/immutable/dist/Immutable.js
There is another module with an equal name when case is ignored.
This can lead to unexpected behavior when compiling on a filesystem with other case-semantic.
Rename module if multiple modules are expected or use equal casing if one module is expected.
```

This pull request fixes the issue.
