### PR TITLE
Expose shouldComponentUpdate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 react-immutable-render-mixin
 ============================
 
-This library exposes 3 distict options for immutable rendering:
+This library exposes 4 distinct options for immutable rendering:
 
 * Mixin for `React.createClass` support
 * HoC ( _decorator_ ) for `React.Component`
-* shouldComponentUpdate function used by the mixin
+* shouldComponentUpdate function used by the mixin and HoC
 * shallowEqualImmutable function to allow custom `shouldComponentUpdate` implementations
 
 This library when used as a mixin/decorator replaces the [PureRenderMixin](http://facebook.github.io/react/docs/pure-render-mixin.html) when using [facebook/immutable-js](https://github.com/facebook/immutable-js) library with [React](https://github.com/facebook/react)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This library exposes 3 distict options for immutable rendering:
 
 * Mixin for `React.createClass` support
 * HoC ( _decorator_ ) for `React.Component`
+* shouldComponentUpdate function used by the mixin
 * shallowEqualImmutable function to allow custom `shouldComponentUpdate` implementations
 
 This library when used as a mixin/decorator replaces the [PureRenderMixin](http://facebook.github.io/react/docs/pure-render-mixin.html) when using [facebook/immutable-js](https://github.com/facebook/immutable-js) library with [React](https://github.com/facebook/react)

--- a/README.md
+++ b/README.md
@@ -66,6 +66,25 @@ class Test extends React.Component {
 }
 ```
 
+Usage with default `shouldComponentUpdate`
+-----
+
+```js
+import React from 'react';
+import { shouldComponentUpdate } from 'react-immutable-render-mixin';
+
+class Test extends React.Component {
+  constructor(props) {
+    super(props);
+    this.shouldComponentUpdate = shouldComponentUpdate.bind(this);
+  }
+
+  render() {
+    return <div></div>;
+  }
+}
+```
+
 Usage with a custom `shouldComponentUpdate`
 -----
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ var immutableRenderMixin = require('react-immutable-render-mixin').default;
 var immutableRenderDecorator = require('react-immutable-render-mixin').immutableRenderDecorator;
 
 var shallowEqualImmutable = require('react-immutable-render-mixin').shallowEqualImmutable;
+
+var shouldComponentUpdate = require('react-immutable-render-mixin').shouldComponentUpdate;
 ```
 
 Full Example:

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+import shouldComponentUpdate from './shouldComponentUpdate';
 import shallowEqualImmutable from './shallowEqualImmutable';
 import immutableRenderMixin from './immutableRenderMixin';
 import immutableRenderDecorator from './immutableRenderDecorator';
@@ -5,5 +6,6 @@ import immutableRenderDecorator from './immutableRenderDecorator';
 export {
   immutableRenderMixin as default,
   immutableRenderDecorator,
-  shallowEqualImmutable,
+  shouldComponentUpdate,
+  shallowEqualImmutable
 };


### PR DESCRIPTION
For React components built on ES6 class, overriding shouldComponentUpdate in class constructor is another way to extend the mixin.