### PR TITLE
Trying to see if `"react": "*"` solves the problem with npm >=3.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "peerDependencies": {
     "immutable": ">=2.0.10",
-    "react": ""
+    "react": "*"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
It's a solution for the #17

Apparently it's an npm bug, since as per the documentation https://docs.npmjs.com/misc/semver `"" (empty string) := * := >=0.0.0` both an empty string and a `*` must behave the same

Relevant:

* https://github.com/npm/npm/issues/11511