### PR TITLE
ignoring babel presets

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 src
 examples
+.babelrc


### PR DESCRIPTION
This confuses projects that hold a different kind of preset altogether (react native).
